### PR TITLE
Update boost location for WAX

### DIFF
--- a/.cicd/platforms/pinned/amazon_linux-2-pinned.dockerfile
+++ b/.cicd/platforms/pinned/amazon_linux-2-pinned.dockerfile
@@ -43,7 +43,7 @@ RUN git clone --depth 1 --single-branch --branch release_80 https://github.com/l
     cd / && \
     rm -rf /llvm
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr/local && \

--- a/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
+++ b/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
@@ -52,7 +52,7 @@ RUN git clone --depth 1 --single-branch --branch release_80 https://github.com/l
     cd / && \
     rm -rf /llvm
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr/local && \

--- a/.cicd/platforms/pinned/macos-10.14-pinned.sh
+++ b/.cicd/platforms/pinned/macos-10.14-pinned.sh
@@ -51,7 +51,7 @@ rm -rf clang8
 # install boost from source
 # Boost Fix: eosio/install/bin/../include/c++/v1/stdlib.h:94:15: fatal error: 'stdlib.h' file not found
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
-curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2
+curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2
 tar -xjf boost_1_71_0.tar.bz2
 cd boost_1_71_0
 ./bootstrap.sh --prefix=/usr/local

--- a/.cicd/platforms/pinned/ubuntu-16.04-pinned.dockerfile
+++ b/.cicd/platforms/pinned/ubuntu-16.04-pinned.dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth 1 --single-branch --branch release_80 https://github.com/l
     cd / && \
     rm -rf /llvm
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr/local && \

--- a/.cicd/platforms/pinned/ubuntu-18.04-pinned.dockerfile
+++ b/.cicd/platforms/pinned/ubuntu-18.04-pinned.dockerfile
@@ -46,7 +46,7 @@ RUN git clone --depth 1 --single-branch --branch release_80 https://github.com/l
     cd / && \
     rm -rf /llvm
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr/local && \

--- a/.cicd/platforms/unpinned/amazon_linux-2-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/amazon_linux-2-unpinned.dockerfile
@@ -16,7 +16,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     cd / && \
     rm -rf cmake-3.13.2.tar.gz /cmake-3.13.2
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --prefix=/usr/local && \

--- a/.cicd/platforms/unpinned/centos-7.7-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/centos-7.7-unpinned.dockerfile
@@ -21,7 +21,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     cd / && \
     rm -rf cmake-3.13.2.tar.gz /cmake-3.13.2
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
     tar -xjf boost_1_71_0.tar.bz2 && \

--- a/.cicd/platforms/unpinned/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/ubuntu-18.04-unpinned.dockerfile
@@ -18,7 +18,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     cd / && \
     rm -rf cmake-3.13.2.tar.gz /cmake-3.13.2
 # build boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+RUN curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --prefix=/usr/local && \

--- a/docs/00_install/01_build-from-source/02_manual-build/03_platforms/amazon_linux-2.md
+++ b/docs/00_install/01_build-from-source/02_manual-build/03_platforms/amazon_linux-2.md
@@ -51,7 +51,7 @@ cd $EOSIO_INSTALL_LOCATION && curl -LO https://cmake.org/files/v3.13/cmake-3.13.
     make install && \
     rm -rf $EOSIO_INSTALL_LOCATION/cmake-3.13.2.tar.gz $EOSIO_INSTALL_LOCATION/cmake-3.13.2
 # build boost
-cd $EOSIO_INSTALL_LOCATION && curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+cd $EOSIO_INSTALL_LOCATION && curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --prefix=$EOSIO_INSTALL_LOCATION && \

--- a/docs/00_install/01_build-from-source/02_manual-build/03_platforms/centos-7.7.md
+++ b/docs/00_install/01_build-from-source/02_manual-build/03_platforms/centos-7.7.md
@@ -58,7 +58,7 @@ cd $EOSIO_INSTALL_LOCATION && curl -LO https://cmake.org/files/v3.13/cmake-3.13.
 # apply clang patch
 cp -f $EOSIO_LOCATION/scripts/clang-devtoolset8-support.patch /tmp/clang-devtoolset8-support.patch
 # build boost
-cd $EOSIO_INSTALL_LOCATION && curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+cd $EOSIO_INSTALL_LOCATION && curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     source /opt/rh/devtoolset-8/enable && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \

--- a/docs/00_install/01_build-from-source/02_manual-build/03_platforms/ubuntu-18.04.md
+++ b/docs/00_install/01_build-from-source/02_manual-build/03_platforms/ubuntu-18.04.md
@@ -51,7 +51,7 @@ cd $EOSIO_INSTALL_LOCATION && curl -LO https://cmake.org/files/v3.13/cmake-3.13.
     make install && \
     rm -rf $EOSIO_INSTALL_LOCATION/cmake-3.13.2.tar.gz $EOSIO_INSTALL_LOCATION/cmake-3.13.2
 # build boost
-cd $EOSIO_INSTALL_LOCATION && curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
+cd $EOSIO_INSTALL_LOCATION && curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --prefix=$EOSIO_INSTALL_LOCATION && \

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -254,7 +254,7 @@ function ensure-boost() {
             local SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
         fi
         execute bash -c "cd $SRC_DIR && \
-        curl -LO https://dl.bintray.com/boostorg/release/$BOOST_VERSION_MAJOR.$BOOST_VERSION_MINOR.$BOOST_VERSION_PATCH/source/boost_$BOOST_VERSION.tar.bz2 \
+        curl -LO https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION_MAJOR.$BOOST_VERSION_MINOR.$BOOST_VERSION_PATCH/source/boost_$BOOST_VERSION.tar.bz2 \
         && tar -xjf boost_$BOOST_VERSION.tar.bz2 \
         && cd $BOOST_ROOT \
         && SDKROOT="$SDKROOT" ./bootstrap.sh ${BOOTSTRAP_FLAGS} --prefix=$BOOST_ROOT \


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
While trying to set up a WAX deep mind node, ran into issues regarding boost. Updating the boost locations for the build script solved the error

This PR replaces all occurrences of `https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2` to `https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2`

![image](https://user-images.githubusercontent.com/20028678/141350563-3815b941-e857-4932-aa51-ab31c0d30bbf.png)

Technically, the only change needed was in the `scripts/helpers/eosio.sh` file, but replaced all just in case to be more aligned with https://github.com/EOSIO/eos/commit/47232a086aeb709d05f6fe72fca7bcba30a3d4cf#diff-6dc16bcfaaa3ded85a8cc90da9fed71728d7b7b8fe7ee7e8ecdac91129102ef8

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
